### PR TITLE
Use <nixpkgs> and default haskellPackages

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -7,7 +7,7 @@ let
   inherit (pkgs) lib;
   hlib = pkgs.haskell.lib;
 
-  hpkgs = pkgs.haskell.packages.ghc865.extend (self: super: {
+  hpkgs = pkgs.haskellPackages.extend (self: super: {
     nixbot = (self.callCabal2nix "nixbot" (lib.sourceByRegex ./. [
       "^src.*$"
       "^.*\\.cabal$"


### PR DESCRIPTION
Feel free to ignore and close this if you like it the current way - I'm not sure how you deploy it but I prefer when pinning is done in `release.nix` or so as this forces me to download ghc865 and other packages :)